### PR TITLE
pin version of prometheus client as 0.5+ is not compatible with sanic-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.1] - 2018-12-12
+### Fixed
+- pin version of prometheus client as 0.5+ is not compatible with sanic-prometheus
+
 ## [0.3.0] - 2018-12-06
 ### Added
 - Support for compiling udunits2
@@ -22,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - make compile process handle more errors
 
-[unreleased]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/:ministryofjustice/analytics-platform-cran-proxy/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.1.1...v0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sanic-envconfig==1.0.1
 urlobject==2.4.3
 python-debian==0.1.33
 sanic-prometheus==0.1.5
+prometheus-client>=0.4,<0.5.0


### PR DESCRIPTION
minor tweak, noticed that rebuilding the dockerfile without cache caused it to install prometheus-client 0.5.x which is not compatible with sanic-prometheus. I've pinned that version