### PR TITLE
Passive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2019-01-11
+### Added
+- passive mode which allows proxy to run without attempting to compile or cache anything
+
+## [0.4.0] - 2019-01-01
+### Added
+- Fat package support
+
 ## [0.3.1] - 2018-12-12
 ### Fixed
 - pin version of prometheus client as 0.5+ is not compatible with sanic-prometheus
@@ -26,7 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - make compile process handle more errors
 
-[unreleased]: https://github.com/:ministryofjustice/analytics-platform-cran-proxy/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ministryofjustice/analytics-platform-cran-proxy/compare/v0.1.1...v0.2.0

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Repos: CRAN=https://cran-proxy.yourdomain.com
 | Name | Default | Description |
 |------------------------- |------------------------------ |-------------------------------------------------------------------------------------------------------- |
 | `DEBUG` | `FALSE` | If set to true the webserver will auto reload on changes, dump exceptions and set the log level to DEBUG |
+| `PASSIVE` | `FALSE` | If set to TRUE, the server will not attempt to compile any packages and will always return source packages |
 | `PORT` | `8000` | TCP Port to listen for HTTP requests on |
 | `UPSTREAM_CRAN_SERVER_URL` | `https://cloud.r-project.org/` | URL of CRAN server we are proxying. <span class="underline">Include trailing slash</span> |
 | `LOG_LEVEL` | `INFO` | Can be one of `INFO`, `WARNING`, `ERROR`, `DEBUG` |

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ class Config(EnvConfig):
     UPSTREAM_CRAN_SERVER_URL: URLObject = URLObject("https://cloud.r-project.org/")
     LOG_LEVEL: str = "INFO"
     BINARY_OUTPUT_PATH: Path = Path("/tmp/bin/")
+    PASSIVE: bool = False
 
 
 class FilterHealthz(logging.Filter):

--- a/server.py
+++ b/server.py
@@ -94,16 +94,17 @@ async def packages(request):
 @app.route("/src/contrib/<path:path>/<package>.tar.gz")
 async def serve_tarfile(request, package, path=None):
 
-    binary_path = (
-        app.config.BINARY_OUTPUT_PATH / f"{package}_R_x86_64-pc-linux-gnu.tar.gz"
-    )
-    if os.path.isfile(binary_path):
-        return await file(binary_path)
-
     cran = URLObject(app.config.UPSTREAM_CRAN_SERVER_URL)
-
     to = cran.add_path(request.path)
-    asyncio.ensure_future(add_to_cache(to))
+
+    if not app.config.PASSIVE:
+        binary_path = (
+            app.config.BINARY_OUTPUT_PATH / f"{package}_R_x86_64-pc-linux-gnu.tar.gz"
+        )
+        if os.path.isfile(binary_path):
+            return await file(binary_path)
+        asyncio.ensure_future(add_to_cache(to))
+
     logger.info(f"serve_tarfile: Redirecting [302] to {to}")
     return redirect(to)
 


### PR DESCRIPTION
For temporally making the proxy a pure proxy, it will not try to compile or
serve compiled packages

enable this by setting a `PASSIVE=TRUE` environment variable